### PR TITLE
fix(ci): guard against dangling venv symlinks and silence xattr noise

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -37,6 +37,19 @@ jobs:
       env:
         PIP_DISABLE_PIP_VERSION_CHECK: '1'
 
+    - name: Check pythondist has no dangling symlinks
+      run: |
+        # Any broken symlink inside the bundled Python tree will surface as
+        # confusing "xattr: No such file" warnings when end users strip the
+        # macOS quarantine attribute. Fail the build instead of shipping them.
+        broken=$(find pythondist -type l ! -exec test -e {} \; -print || true)
+        if [ -n "$broken" ]; then
+          echo "Dangling symlinks found in pythondist:"
+          echo "$broken"
+          exit 1
+        fi
+        echo "No dangling symlinks in pythondist."
+
     - name: Verify and test YOLO environment
       env:
         SMOKE_TEST_YOLO: '1'
@@ -184,12 +197,13 @@ jobs:
 
     - name: Remove quarantine attributes from built app
       run: |
-        # Find and remove quarantine from .app bundles to prevent "damaged app" errors
+        # Find and remove quarantine from .app bundles to prevent "damaged app" errors.
+        # Use find with -not -type l so we never try to follow a symlink — that's
+        # what produces "xattr: No such file" warnings users have reported.
         for app in dist/*.app; do
           if [ -d "$app" ]; then
             echo "Removing quarantine attributes from: $app"
-            xattr -cr "$app" || true
-            # Verify removal
+            find "$app" -not -type l -exec xattr -d com.apple.quarantine {} \; 2>/dev/null || true
             if xattr -l "$app" 2>/dev/null | grep -q "com.apple.quarantine"; then
               echo "Warning: Quarantine still present on $app"
             else

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -197,18 +197,23 @@ jobs:
 
     - name: Remove quarantine attributes from built app
       run: |
-        # Find and remove quarantine from .app bundles to prevent "damaged app" errors.
-        # Use find with -not -type l so we never try to follow a symlink — that's
-        # what produces "xattr: No such file" warnings users have reported.
-        for app in dist/*.app; do
-          if [ -d "$app" ]; then
-            echo "Removing quarantine attributes from: $app"
-            find "$app" -not -type l -exec xattr -d com.apple.quarantine {} \; 2>/dev/null || true
-            if xattr -l "$app" 2>/dev/null | grep -q "com.apple.quarantine"; then
-              echo "Warning: Quarantine still present on $app"
-            else
-              echo "Successfully cleaned: $app"
-            fi
+        # electron-builder writes the .app inside dist/<target>/ (e.g.
+        # dist/mac-arm64/TinyExplorer Detection App.app), not directly in
+        # dist/, so use `find` to locate it. Skip symlinks (-not -type l)
+        # so we never try to follow a dangling link — that's what produces
+        # "xattr: No such file" warnings users have reported.
+        apps=$(find dist -maxdepth 3 -name '*.app' -type d)
+        if [ -z "$apps" ]; then
+          echo "No .app bundles found under dist/"
+          exit 0
+        fi
+        echo "$apps" | while IFS= read -r app; do
+          echo "Removing quarantine attributes from: $app"
+          find "$app" -not -type l -exec xattr -d com.apple.quarantine {} \; 2>/dev/null || true
+          if xattr -l "$app" 2>/dev/null | grep -q "com.apple.quarantine"; then
+            echo "Warning: Quarantine still present on $app"
+          else
+            echo "Successfully cleaned: $app"
           fi
         done
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,7 +36,19 @@ Choose your operating system below for specific installation instructions:
          sudo xattr -r -d com.apple.quarantine /Applications/TinyExplorer\ Detection\ App.app
          ```
     5. Press **Enter** and type your Mac password when prompted
-    
+
+    !!! note "If you see `xattr: No such file` messages"
+        On some older builds the command prints a few warnings like
+        `xattr: No such file: .../python3.10`. These are **harmless** — they
+        refer to internal Python links inside the app bundle and do not mean
+        anything failed. The quarantine flag is still removed correctly and
+        the app will launch.
+
+        If you'd prefer a silent version, you can run instead:
+        ```bash
+        sudo xattr -r -d com.apple.quarantine /Applications/TinyExplorer\ Detection\ App.app 2>/dev/null
+        ```
+
     !!! tip "What does this command do?"
         - `sudo` - Runs the command with administrator privileges
         - `xattr` - Modifies file attributes

--- a/scripts/bundle-python-standalone.js
+++ b/scripts/bundle-python-standalone.js
@@ -204,14 +204,15 @@ async function createVirtualEnvironments(pythonStandaloneDir) {
     
     console.log('Creating virtual environments with standalone Python...');
     
-    // Create YOLO virtual environment
-    // Use --copies so venv/bin/python* are real binaries, not symlinks.
-    // Symlinks dangle after electron-builder packaging and cause
-    // confusing "xattr: No such file" warnings when users strip quarantine.
+    // Create YOLO virtual environment.
+    // NOTE: do not pass --copies. python-build-standalone resolves sys.prefix
+    // from the binary's install location; copying the binary breaks stdlib
+    // discovery and `ensurepip` SIGABRTs. Use symlinks and rely on
+    // fixVenvPythonSymlinks() to keep them relative for relocatability.
     console.log('Creating YOLO virtual environment...');
-    execSync(`"${pythonExe}" -m venv --copies "${yoloEnvDir}"`, { stdio: 'inherit' });
+    execSync(`"${pythonExe}" -m venv "${yoloEnvDir}"`, { stdio: 'inherit' });
 
-    // Ensure no stray absolute/dotted symlinks remain (no-op when --copies worked)
+    // Fix symlinks to be relative for relocatability
     fixVenvPythonSymlinks(yoloEnvDir, pythonStandaloneDir);
     // Install YOLO packages
     const yoloPython = platform === 'win32'
@@ -231,8 +232,9 @@ async function createVirtualEnvironments(pythonStandaloneDir) {
     
     // Create RetinaFace virtual environment (see comment above re: --copies)
     console.log('Creating RetinaFace virtual environment...');
-    execSync(`"${pythonExe}" -m venv --copies "${retinafaceEnvDir}"`, { stdio: 'inherit' });
+    execSync(`"${pythonExe}" -m venv "${retinafaceEnvDir}"`, { stdio: 'inherit' });
 
+    // Fix symlinks to be relative for relocatability
     fixVenvPythonSymlinks(retinafaceEnvDir, pythonStandaloneDir);
     
     // Install RetinaFace packages

--- a/scripts/bundle-python-standalone.js
+++ b/scripts/bundle-python-standalone.js
@@ -205,10 +205,13 @@ async function createVirtualEnvironments(pythonStandaloneDir) {
     console.log('Creating virtual environments with standalone Python...');
     
     // Create YOLO virtual environment
+    // Use --copies so venv/bin/python* are real binaries, not symlinks.
+    // Symlinks dangle after electron-builder packaging and cause
+    // confusing "xattr: No such file" warnings when users strip quarantine.
     console.log('Creating YOLO virtual environment...');
-    execSync(`"${pythonExe}" -m venv "${yoloEnvDir}"`, { stdio: 'inherit' });
-    
-    // Fix symlinks to be relative for relocatability
+    execSync(`"${pythonExe}" -m venv --copies "${yoloEnvDir}"`, { stdio: 'inherit' });
+
+    // Ensure no stray absolute/dotted symlinks remain (no-op when --copies worked)
     fixVenvPythonSymlinks(yoloEnvDir, pythonStandaloneDir);
     // Install YOLO packages
     const yoloPython = platform === 'win32'
@@ -226,11 +229,10 @@ async function createVirtualEnvironments(pythonStandaloneDir) {
         env: { ...process.env, PIP_DISABLE_PIP_VERSION_CHECK: '1' }
     });
     
-    // Create RetinaFace virtual environment
+    // Create RetinaFace virtual environment (see comment above re: --copies)
     console.log('Creating RetinaFace virtual environment...');
-    execSync(`"${pythonExe}" -m venv "${retinafaceEnvDir}"`, { stdio: 'inherit' });
-    
-    // Fix symlinks to be relative for relocatability
+    execSync(`"${pythonExe}" -m venv --copies "${retinafaceEnvDir}"`, { stdio: 'inherit' });
+
     fixVenvPythonSymlinks(retinafaceEnvDir, pythonStandaloneDir);
     
     // Install RetinaFace packages


### PR DESCRIPTION
## Summary

Users on macOS were seeing scary-looking warnings when running the documented quarantine-removal command on the installed `.app`:

\`\`\`
xattr: No such file: .../pythondist/retinaface-env/bin/python3.10
xattr: No such file: .../pythondist/retinaface-env/bin/python
...
\`\`\`

These are emitted when \`xattr -r\` follows symlinks inside the bundled Python venvs and the target doesn't resolve. The quarantine flag is still removed and the app still launches, but the warnings make users think something is broken.

This PR addresses the issue at three layers:

- **Build-time guard** — new "Check pythondist has no dangling symlinks" step fails the build if any broken symlink slips into \`pythondist/\`. Verified working: prints \`No dangling symlinks in pythondist.\` on a clean build (run [25881979803](https://github.com/cardiff-babylab/tinyexplorer-detection-app/actions/runs/25881979803)).
- **Quarantine-strip robustness** — the existing post-build step was a pre-existing no-op (loop \`for app in dist/*.app\` never matched because electron-builder writes to \`dist/mac-arm64/\`). Now uses \`find dist -maxdepth 3 -name '*.app' -type d\` so it actually finds the bundle. Also skips symlinks via \`find -not -type l\` so it cannot emit "No such file" warnings.
- **User-facing docs** — added a callout in \`docs/getting-started.md\` explaining the warnings are harmless and offering a silent variant (\`sudo xattr -r -d com.apple.quarantine ... 2>/dev/null\`).

### What I tried that didn't work

Initial attempt used \`python -m venv --copies\` to bundle real binaries instead of symlinks. This **fails** with \`python-build-standalone\`: copying the standalone interpreter out of its install tree breaks \`sys.prefix\` resolution, so \`ensurepip\` SIGABRTs (run [25881819599](https://github.com/cardiff-babylab/tinyexplorer-detection-app/actions/runs/25881819599)). Reverted — symlinks + \`fixVenvPythonSymlinks()\` is the right approach for this interpreter.

## Test plan

- [x] CI passes on \`fix/venv-copies-ci\` (run 25881979803, 6m46s)
- [x] New guard step prints \`No dangling symlinks in pythondist.\`
- [x] Local repro confirms broken symlink → guard fails, valid symlink → guard passes
- [x] Local repro confirms \`find -not -type l -exec xattr\` strips \`com.apple.quarantine\` without emitting warnings on dangling links
- [ ] After merge, verify the quarantine-strip step's output ("Removing quarantine attributes from: …" / "Successfully cleaned: …") shows up in CI logs (it was silently skipped before this PR)