### PR TITLE
perf(startup): lazy-load ML stacks, add splash + startup timing

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Build site
         run: mkdocs build --strict
       - name: Deploy to gh-pages branch
+        # Only publish on push to main (or manual dispatch), never on pull_request.
+        # PRs from forks get a read-only GITHUB_TOKEN, so the deploy push 403s, and
+        # a PR should not publish docs to the production gh-pages branch anyway.
+        # The `mkdocs build --strict` step above still runs on PRs to validate docs.
+        if: github.event_name != 'pull_request'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,9 @@ Thumbs.db
 test-results/
 playwright-report/
 tests/
+# ...but keep the Python unit tests, which live in python/tests/
+!python/tests/
+!python/tests/**
 
 # Keep important files
 !README.md

--- a/main/index.ts
+++ b/main/index.ts
@@ -12,6 +12,17 @@ import { app, BrowserWindow, ipcMain, dialog, shell, Tray, Menu, nativeImage } f
 import * as path from "path";
 import * as fs from "fs";
 
+// Wall-clock at main-process entry, used for lightweight startup phase timing.
+// Verbose [timing] lines are gated behind the STARTUP_TIMING env var; the phase
+// marks below let us measure process-start -> window-shown -> python-ready.
+const processStart = Date.now();
+const startupTimingEnabled = Boolean(process.env.STARTUP_TIMING);
+function logStartupTiming(phase: string) {
+    if (startupTimingEnabled) {
+        try { console.log(`[timing] ${phase} ${Date.now() - processStart}ms`); } catch (e) {}
+    }
+}
+
 // Speech detection requires audio, which only video files have. Use this to
 // gate the "Speech" mode button in the renderer. We bail early on first match
 // and cap the walk to keep huge folders responsive.
@@ -68,6 +79,57 @@ if (process.platform === 'win32') {
 const isDev = (process.env.NODE_ENV === "development");
 let tray: Tray | null = null;
 let mainWindow: BrowserWindow | null = null;
+let splash: BrowserWindow | null = null;
+
+// Minimal, self-contained splash shown the instant the app starts, so the user
+// sees immediate feedback instead of a blank screen while the React bundle loads
+// and the Python backend warms up. Kept as an inline data URL (no external assets,
+// no extra packaged files) so it always renders, even before first paint of the
+// main window. Closed once the main window is ready-to-show (or Python is ready).
+const SPLASH_HTML = `<!doctype html><html><head><meta charset="utf-8"><style>
+  html,body{margin:0;height:100%;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif}
+  body{display:flex;flex-direction:column;align-items:center;justify-content:center;
+       background:linear-gradient(135deg,#1e293b,#0f172a);color:#e2e8f0;-webkit-user-select:none}
+  .title{font-size:18px;font-weight:600;margin-bottom:6px}
+  .sub{font-size:12px;color:#94a3b8;margin-bottom:22px}
+  .dots{display:flex;gap:8px}
+  .dot{width:9px;height:9px;border-radius:50%;background:#38bdf8;animation:b 1.2s infinite ease-in-out}
+  .dot:nth-child(2){animation-delay:.15s}.dot:nth-child(3){animation-delay:.3s}
+  @keyframes b{0%,80%,100%{opacity:.25;transform:scale(.8)}40%{opacity:1;transform:scale(1)}}
+</style></head><body>
+  <div class="title">TinyExplorer Detection App</div>
+  <div class="sub">Starting up&hellip;</div>
+  <div class="dots"><div class="dot"></div><div class="dot"></div><div class="dot"></div></div>
+</body></html>`;
+
+function createSplash() {
+    try {
+        splash = new BrowserWindow({
+            width: 360,
+            height: 220,
+            frame: false,
+            resizable: false,
+            center: true,
+            show: true,
+            skipTaskbar: true,
+            webPreferences: {},
+        });
+        splash.loadURL("data:text/html;charset=utf-8," + encodeURIComponent(SPLASH_HTML));
+        // Safety net: never let the splash outlive startup, even if 'ready-to-show'
+        // never fires for some reason.
+        setTimeout(closeSplash, 30000);
+    } catch (e) {
+        try { console.error("Failed to create splash window:", e); } catch (e2) {}
+        splash = null;
+    }
+}
+
+function closeSplash() {
+    if (splash && !splash.isDestroyed()) {
+        try { splash.close(); } catch (e) {}
+    }
+    splash = null;
+}
 
 // Add isQuitting property to app instance
 (app as any).isQuitting = false;
@@ -91,14 +153,18 @@ app.on('before-quit', () => {
 });
 
 app.on("ready", () => {
+    logStartupTiming("app_ready");
     if (isDev) {
         const sourceMapSupport = require("source-map-support"); // tslint:disable-line
         sourceMapSupport.install();
     }
-    
+
+    // Show the splash immediately so the user gets instant visual feedback.
+    createSplash();
+
     // Import Python subprocess handler after app is ready
     require("./with-python-subprocess");
-    
+
     createWindow();
     createTray();
 });
@@ -224,12 +290,26 @@ function createWindow() {
     
     mainWindow = new BrowserWindow({
         icon: windowIconPath,
+        // Start hidden and reveal on 'ready-to-show' so the user never sees a
+        // blank white window while the React bundle loads; the splash covers the
+        // gap until then.
+        show: false,
         webPreferences: {
             nodeIntegration: true,
             contextIsolation: false
         }
     });
-    
+
+    // Reveal the main window once its first paint is ready, then dismiss the splash.
+    mainWindow.once("ready-to-show", () => {
+        logStartupTiming("window_shown");
+        if (mainWindow) {
+            mainWindow.show();
+            mainWindow.focus();
+        }
+        closeSplash();
+    });
+
     if (isDev) {
         mainWindow.webContents.openDevTools();
     }

--- a/main/with-python-subprocess.ts
+++ b/main/with-python-subprocess.ts
@@ -11,6 +11,15 @@ const PY_LAUNCHER = "launcher"; // Launcher script for packaged mode
 
 const isDev = (process.env.NODE_ENV === "development");
 
+// Lightweight startup phase timing, gated behind STARTUP_TIMING (see main/index.ts).
+const subprocStart = Date.now();
+const startupTimingEnabled = Boolean(process.env.STARTUP_TIMING);
+function logStartupTiming(phase: string, extra?: string) {
+    if (startupTimingEnabled) {
+        try { console.log(`[timing] ${phase} ${Date.now() - subprocStart}ms${extra ? " " + extra : ""}`); } catch (e) {}
+    }
+}
+
 let pyProc: childProcess.ChildProcess | null = null;
 let pythonReady = false;
 let commandQueue: Array<{command: any, callback: Function}> = [];
@@ -286,7 +295,8 @@ const initializePython = async () => {
         cwd: path.dirname(scriptPath), // Set working directory to script location
         env: spawnEnv,
     });
-    
+    logStartupTiming("python_spawned");
+
     if (!pyProc) {
         try { console.log("Failed to start Python subprocess"); } catch (e) {}
         dialog.showErrorBox("Error", "Failed to start Python subprocess");
@@ -453,13 +463,16 @@ const handlePythonMessage = (message: any) => {
     if (message.type === 'ready') {
         pythonReady = true;
         try { console.log("Python subprocess is ready"); } catch (e) {}
-        
+        // message.startupMs is the Python-measured process-entry -> ready time.
+        logStartupTiming("python_ready", message.startupMs !== undefined ? `(python startupMs=${message.startupMs})` : undefined);
+
         // Notify all renderer processes that Python is ready
         const allWindows = Electron.BrowserWindow.getAllWindows();
         allWindows.forEach(window => {
             window.webContents.send('pythonStatus', {
                 ready: pythonReady,
-                pid: pyProc ? pyProc.pid : undefined
+                pid: pyProc ? pyProc.pid : undefined,
+                startupMs: message.startupMs
             });
         });
         

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
         "setup-dev-envs": "node -e \"console.log(process.platform === 'win32' ? 'Running Windows setup...' : 'Running Unix setup...')\" && node -e \"require('child_process').execSync(process.platform === 'win32' ? 'scripts\\\\setup-dev-environments.bat' : './scripts/setup-dev-environments.sh', {stdio: 'inherit'})\"",
         "test": "npm run test:gui",
         "test:gui": "playwright test",
-        "test:gui:headed": "playwright test --headed"
+        "test:gui:headed": "playwright test --headed",
+        "test:python": "python -m pytest python/tests -v"
     },
     "dependencies": {
         "@types/cross-spawn": "^6.0.0",

--- a/python/detectors/face_retinaface.py
+++ b/python/detectors/face_retinaface.py
@@ -8,8 +8,8 @@ work for video frames extracted in-memory).
 
 from __future__ import annotations
 
+import importlib.util
 import logging
-import sys
 from typing import List, Optional
 
 import numpy as np
@@ -18,14 +18,11 @@ from .base import Detection, VisionDetector, register_detector
 
 logger = logging.getLogger(__name__)
 
-_RETINAFACE_AVAILABLE = False
-try:
-    from retinaface import RetinaFace  # type: ignore
-
-    _RETINAFACE_AVAILABLE = True
-    print("RetinaFace loaded successfully", file=sys.stderr)
-except ImportError as e:
-    print(f"RetinaFace not available: {e}", file=sys.stderr)
+# NOTE: retina-face (and the TensorFlow it pulls in) is intentionally NOT imported
+# at module load time — TensorFlow's cold import is a multi-second startup cost that
+# would block the subprocess "ready" signal on every launch. It is imported lazily
+# inside load()/detect_image() instead, and availability is probed cheaply via
+# importlib.util (which does not execute the module).
 
 
 @register_detector("face_retinaface")
@@ -36,7 +33,11 @@ class FaceRetinaFaceDetector(VisionDetector):
     variants = ["RetinaFace"]
 
     def load(self, weights_dir: str, variant: Optional[str] = None) -> bool:
-        if not _RETINAFACE_AVAILABLE:
+        # Heavy import (retina-face + TensorFlow) happens here lazily, not at
+        # module load time.
+        try:
+            from retinaface import RetinaFace  # type: ignore  # noqa: F401
+        except ImportError:
             self._emit("RetinaFace is not available in this environment")
             self._emit(
                 "Ensure 'retina-face' and 'tensorflow' are installed in the active Python environment"
@@ -48,10 +49,12 @@ class FaceRetinaFaceDetector(VisionDetector):
         return True
 
     def detect_image(self, image: np.ndarray, confidence_threshold: float) -> List[Detection]:
-        if not _RETINAFACE_AVAILABLE:
+        try:
+            from retinaface import RetinaFace  # type: ignore
+        except ImportError as e:
             raise RuntimeError(
                 "FaceRetinaFaceDetector.detect_image called but retina-face is not installed"
-            )
+            ) from e
 
         face_detections = RetinaFace.detect_faces(image, threshold=confidence_threshold)
         detections: List[Detection] = []
@@ -77,4 +80,6 @@ class FaceRetinaFaceDetector(VisionDetector):
 
 
 def is_available() -> bool:
-    return _RETINAFACE_AVAILABLE
+    """Whether retina-face is importable, probed cheaply via importlib.util so we
+    do NOT import TensorFlow just to answer this."""
+    return importlib.util.find_spec("retinaface") is not None

--- a/python/detectors/face_yolo.py
+++ b/python/detectors/face_yolo.py
@@ -10,9 +10,9 @@ behaviour of the YOLO branch in the original face_detection.py:
 
 from __future__ import annotations
 
+import importlib.util
 import logging
 import os
-import sys
 from typing import List, Optional
 
 import numpy as np
@@ -22,15 +22,13 @@ from .base import Detection, VisionDetector, register_detector
 
 logger = logging.getLogger(__name__)
 
-_YOLO_AVAILABLE = False
-try:
-    from ultralytics import YOLO
-    import torch
-
-    _YOLO_AVAILABLE = True
-    print("YOLO/Ultralytics loaded successfully", file=sys.stderr)
-except ImportError as e:
-    print(f"YOLO/Ultralytics not available: {e}", file=sys.stderr)
+# NOTE: torch and ultralytics are intentionally NOT imported at module load time.
+# They are the single largest contributor to app startup latency (multi-second
+# cold import), and importing them here would block the Python subprocess's
+# "ready" signal — and therefore the app's loading screen — on every launch.
+# Instead we import them lazily inside load()/_select_device(), i.e. only when a
+# detection actually runs. Availability is probed cheaply via importlib.util so
+# the model list can be populated without paying the import cost.
 
 
 _RELEASE_BASE = (
@@ -61,8 +59,11 @@ class FaceYoloDetector(VisionDetector):
         self.weights_path: Optional[str] = None
 
     def load(self, weights_dir: str, variant: Optional[str] = None) -> bool:
-        if not _YOLO_AVAILABLE:
-            self._emit("YOLO/Ultralytics is not available in this environment")
+        # Heavy imports happen here (lazily), not at module import time.
+        try:
+            from ultralytics import YOLO
+        except ImportError as e:
+            self._emit(f"YOLO/Ultralytics is not available in this environment: {e}")
             return False
 
         variant = variant or self.variants[0]
@@ -162,7 +163,9 @@ class FaceYoloDetector(VisionDetector):
 
     @staticmethod
     def _select_device() -> str:
-        if not _YOLO_AVAILABLE:
+        try:
+            import torch
+        except ImportError:
             return "cpu"
         if torch.backends.mps.is_available():
             return "mps"
@@ -173,5 +176,12 @@ class FaceYoloDetector(VisionDetector):
 
 def is_available() -> bool:
     """Whether YOLO/Ultralytics is importable. Used by the orchestrator's
-    legacy ``get_available_models``."""
-    return _YOLO_AVAILABLE
+    legacy ``get_available_models``.
+
+    Uses ``importlib.util.find_spec`` so we can report availability WITHOUT
+    actually importing torch/ultralytics (which would defeat the lazy-load and
+    slow startup). find_spec only locates the module; it does not execute it."""
+    return (
+        importlib.util.find_spec("ultralytics") is not None
+        and importlib.util.find_spec("torch") is not None
+    )

--- a/python/multi_env_launcher.py
+++ b/python/multi_env_launcher.py
@@ -6,50 +6,68 @@ Dynamically switches between YOLO and RetinaFace environments based on model sel
 import sys
 import os
 import json
+import time
+
+# Wall-clock at process entry, used for lightweight startup phase timing.
+# Verbose [timing] lines are gated behind the STARTUP_TIMING env var; enable
+# with e.g. `STARTUP_TIMING=1 npm start` to profile launch performance.
+_LAUNCH_T0 = time.time()
+_TIMING_ENABLED = bool(os.environ.get("STARTUP_TIMING"))
+
+
+def _emit_timing(phase):
+    """Print a `[timing] <phase> <ms>` line to stderr when profiling is on.
+
+    The Electron main process forwards Python stderr to the renderer as
+    `python-event`, so these also show up in DevTools during dev runs."""
+    if _TIMING_ENABLED:
+        elapsed_ms = (time.time() - _LAUNCH_T0) * 1000
+        print(f"[timing] {phase} {elapsed_ms:.0f}ms", file=sys.stderr, flush=True)
+
 
 def setup_python_path(model_type='yolo'):
     """Add bundled dependencies to Python path based on model type"""
     # Get the directory where this launcher script is located
     script_dir = os.path.dirname(os.path.abspath(__file__))
     parent_dir = os.path.dirname(script_dir)
-    
+
     # Check if we're in development mode (source files) or packaged mode
-    # Development mode: script_dir is in the source python/ directory 
+    # Development mode: script_dir is in the source python/ directory
     # Packaged mode: script_dir is in pythondist/python/ inside app bundle
-    is_development = (os.path.exists(os.path.join(script_dir, '../src')) or 
-                     (os.path.basename(script_dir) == 'python' and 
+    is_development = (os.path.exists(os.path.join(script_dir, '../src')) or
+                     (os.path.basename(script_dir) == 'python' and
                       os.path.basename(os.path.dirname(script_dir)) != 'pythondist'))
-    
+
     print(f"Environment Detection:", file=sys.stderr)
     print(f"  Script directory: {script_dir}", file=sys.stderr)
-    print(f"  Parent directory: {parent_dir}", file=sys.stderr) 
+    print(f"  Parent directory: {parent_dir}", file=sys.stderr)
     print(f"  Development mode: {is_development}", file=sys.stderr)
     print(f"  Model type: {model_type}", file=sys.stderr)
-    
+
     if is_development:
         # Development mode - Python environment switching handles dependencies via conda
         print(f"Development mode detected - using conda environment for {model_type} models", file=sys.stderr)
-        
+
         # In development mode, the conda environment should already be set up correctly
         # Just add the script directory to the path
         if script_dir not in sys.path:
             sys.path.insert(0, script_dir)
-        
+
         print(f"Added script directory to path: {script_dir}", file=sys.stderr)
     else:
         # Packaged mode - use bundled dependencies
         print(f"Packaged mode detected - using bundled dependencies for {model_type} models", file=sys.stderr)
-        
+
         # Add the script directory to the path
         if script_dir not in sys.path:
             sys.path.insert(0, script_dir)
-        
+
         # Determine the appropriate environment directory
         if model_type == 'retinaface':
             env_dir = os.path.join(parent_dir, 'retinaface-env')
         else:
             env_dir = os.path.join(parent_dir, 'yolo-env')
-        
+
         # Check if the environment directory exists
         if os.path.exists(env_dir):
             # Check if this is a virtual environment
@@ -58,7 +76,7 @@ def setup_python_path(model_type='yolo'):
                 # This is a virtual environment, set sys.executable
                 sys.executable = venv_python
                 print(f"Set virtual environment python: {venv_python}", file=sys.stderr)
-            
+
             # Use virtual environment's site-packages directory by auto-detecting version
             site_packages_dir = None
             # Common layout: <env>/lib/pythonX.Y/site-packages
@@ -75,33 +93,33 @@ def setup_python_path(model_type='yolo'):
                 win_candidate = os.path.join(env_dir, 'Lib', 'site-packages')
                 if os.path.exists(win_candidate):
                     site_packages_dir = win_candidate
-            
+
             # Add site-packages directory to the beginning of sys.path
             if site_packages_dir and os.path.exists(site_packages_dir) and site_packages_dir not in sys.path:
                 sys.path.insert(0, site_packages_dir)
                 print(f"Added {model_type} site-packages to path: {site_packages_dir}", file=sys.stderr)
-            
+
             # Also add the environment directory itself for any loose modules
             if env_dir not in sys.path:
                 sys.path.insert(0, env_dir)
             print(f"Added {model_type} environment to path: {env_dir}", file=sys.stderr)
-            
+
             # Set PYTHONPATH to include site-packages
             if site_packages_dir and os.path.exists(site_packages_dir):
                 sep = ';' if os.name == 'nt' else ':'
                 os.environ['PYTHONPATH'] = site_packages_dir + sep + env_dir
             else:
                 os.environ['PYTHONPATH'] = env_dir
-            
+
             # Clear any existing imports to avoid conflicts
             modules_to_clear = []
             for module in list(sys.modules.keys()):
                 if any(pkg in module for pkg in ['numpy', 'torch', 'tensorflow', 'cv2', 'ultralytics']):
                     modules_to_clear.append(module)
-            
+
             for module in modules_to_clear:
                 del sys.modules[module]
-            
+
         else:
             print(f"Warning: Environment directory not found: {env_dir}", file=sys.stderr)
             print(f"Available directories in {parent_dir}:", file=sys.stderr)
@@ -112,65 +130,50 @@ def setup_python_path(model_type='yolo'):
                         print(f"  {item}/", file=sys.stderr)
             except Exception as e:
                 print(f"  Error listing directory: {e}", file=sys.stderr)
-    
+
     # Log Python path for debugging
     print(f"Python path setup complete. Script dir: {script_dir}", file=sys.stderr)
     print(f"Python version: {sys.version}", file=sys.stderr)
     print(f"Python executable: {sys.executable}", file=sys.stderr)
-    
-    # Test for critical dependencies based on model type
-    print(f"Testing dependencies for {model_type} environment:", file=sys.stderr)
+
+    # Check for critical dependencies based on model type.
+    #
+    # IMPORTANT: we deliberately do NOT import torch/tensorflow/ultralytics/
+    # retinaface here. Actually importing them is a multi-second cold-start cost,
+    # and the detector modules already import them lazily on first use. Probing
+    # with importlib.util.find_spec only locates the modules (no execution), so
+    # this diagnostic stays effectively free and off the startup critical path.
+    import importlib.util
+
+    def _spec_report(module_name, label):
+        available = importlib.util.find_spec(module_name) is not None
+        mark = "✅" if available else "❌"
+        state = "available" if available else "NOT found"
+        print(f"  {mark} {label} {state}", file=sys.stderr)
+
+    print(f"Checking dependencies for {model_type} environment (import-free probe):", file=sys.stderr)
     if model_type == 'yolo':
-        try:
-            import torch
-            print(f"  ✅ PyTorch {torch.__version__} available", file=sys.stderr)
-        except ImportError as e:
-            print(f"  ❌ PyTorch not available: {e}", file=sys.stderr)
-        
-        try:
-            import ultralytics
-            print(f"  ✅ Ultralytics {ultralytics.__version__} available", file=sys.stderr)
-        except ImportError as e:
-            print(f"  ❌ Ultralytics not available: {e}", file=sys.stderr)
-    
+        _spec_report('torch', 'PyTorch')
+        _spec_report('ultralytics', 'Ultralytics')
     elif model_type == 'retinaface':
-        # Cross-platform check: verify dependencies instead of hard-gating by platform
-        try:
-            # Reduce TF logs
-            os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
-            import tensorflow as tf  # noqa: F401
-            print(f"  ✅ TensorFlow available", file=sys.stderr)
-        except Exception as e:
-            print(f"  ❌ TensorFlow not available for RetinaFace: {e}", file=sys.stderr)
-        
-        try:
-            import retinaface  # noqa: F401
-            print(f"  ✅ RetinaFace available", file=sys.stderr)
-        except Exception as e:
-            print(f"  ❌ RetinaFace not available: {e}", file=sys.stderr)
-    
-    # Test common dependencies
-    try:
-        import cv2
-        print(f"  ✅ OpenCV {cv2.__version__} available", file=sys.stderr)
-    except ImportError as e:
-        print(f"  ❌ OpenCV not available: {e}", file=sys.stderr)
-    
-    try:
-        import numpy as np
-        print(f"  ✅ NumPy {np.__version__} available", file=sys.stderr)
-    except ImportError as e:
-        print(f"  ❌ NumPy not available: {e}", file=sys.stderr)
+        # Reduce TF logs when TensorFlow is eventually imported (on first detection).
+        os.environ.setdefault('TF_CPP_MIN_LOG_LEVEL', '2')
+        _spec_report('tensorflow', 'TensorFlow')
+        _spec_report('retinaface', 'RetinaFace')
+
+    # Common dependencies.
+    _spec_report('cv2', 'OpenCV')
+    _spec_report('numpy', 'NumPy')
 
 def detect_model_type():
     """Detect model type from environment or default to YOLO"""
     # Check environment variable first
     model_type = os.environ.get('MODEL_TYPE', 'yolo')
-    
+
     # Check command line args
     if len(sys.argv) > 1 and 'retinaface' in sys.argv[1].lower():
         model_type = 'retinaface'
-    
+
     return model_type
 
 def main():
@@ -178,18 +181,20 @@ def main():
     try:
         # Detect which model environment we need
         model_type = detect_model_type()
-        
+
         # Setup Python path for the appropriate environment
         setup_python_path(model_type)
-        
+        _emit_timing("path_setup_done")
+
         # Now import and run the subprocess API
         # Import here after path is set up
         import subprocess_api
-        
+        _emit_timing("subprocess_api_imported")
+
         # Create and run the API
         api = subprocess_api.SubprocessAPI()
         api.run()
-        
+
     except ImportError as e:
         error_msg = {
             "type": "error",
@@ -201,7 +206,7 @@ def main():
         sys.exit(1)
     except Exception as e:
         error_msg = {
-            "type": "error", 
+            "type": "error",
             "message": f"Launcher error: {str(e)}"
         }
         print(json.dumps(error_msg))

--- a/python/subprocess_api.py
+++ b/python/subprocess_api.py
@@ -11,8 +11,26 @@ import threading
 import time
 import signal
 import atexit
+
+# Startup timing anchor. On Windows the multi_env_launcher is bypassed and this
+# module is the process entry point, so we anchor timing here rather than relying
+# on the launcher. Verbose [timing] lines are gated behind STARTUP_TIMING; the
+# startupMs field on the ready message is always sent (it is tiny).
+_STARTUP_T0 = time.time()
+_TIMING_ENABLED = bool(os.environ.get("STARTUP_TIMING"))
+
 from calc import calc as real_calc
+# NOTE: importing face_detection pulls in the detector registry. Thanks to the
+# detectors' lazy imports, this no longer drags in torch/TensorFlow, so it stays
+# cheap and does not block the "ready" signal below.
 from face_detection import FaceDetectionProcessor
+
+if _TIMING_ENABLED:
+    print(
+        f"[timing] face_detection_imported {(time.time() - _STARTUP_T0) * 1000:.0f}ms",
+        file=sys.stderr,
+        flush=True,
+    )
 
 class SubprocessAPI:
     def __init__(self):
@@ -272,8 +290,16 @@ class SubprocessAPI:
         """Main subprocess loop - read commands from stdin and send responses to stdout"""
         self.logger.info("Starting subprocess API...")
         
-        # Send ready signal
-        self.send_response({'type': 'ready', 'message': 'Python subprocess ready'})
+        # Send ready signal. startupMs measures process-entry -> ready, which the
+        # Electron main surfaces so we have a concrete launch-time metric.
+        startup_ms = round((time.time() - _STARTUP_T0) * 1000)
+        if _TIMING_ENABLED:
+            print(f"[timing] ready {startup_ms}ms", file=sys.stderr, flush=True)
+        self.send_response({
+            'type': 'ready',
+            'message': 'Python subprocess ready',
+            'startupMs': startup_ms,
+        })
         
         while self.running:
             try:

--- a/python/tests/test_lazy_imports.py
+++ b/python/tests/test_lazy_imports.py
@@ -1,0 +1,161 @@
+"""Regression tests locking in the lazy-load of the heavy ML stacks.
+
+The app's Python subprocess emits its "ready" signal (which dismisses the
+loading screen) only after its imports finish. Historically the detector
+modules imported torch/ultralytics (YOLO) and tensorflow/retina-face at module
+top level, so "ready" was gated behind a multi-second cold import on every
+launch. These tests assert that importing the detector registry and the
+orchestrator does NOT drag torch/TensorFlow into ``sys.modules`` — if anyone
+re-introduces a top-level heavy import, these fail.
+
+The tests only need the light deps (numpy, opencv, requests). torch/TF do not
+need to be installed for the guard to be meaningful: when they ARE installed,
+an accidental eager import would show up in ``sys.modules`` here; when they are
+NOT installed, the lazy code path is exercised and must still succeed.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+# Make the bundled ``python/`` modules importable regardless of where pytest is
+# invoked from (tests live in ``python/tests/``).
+PYTHON_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PYTHON_DIR not in sys.path:
+    sys.path.insert(0, PYTHON_DIR)
+
+_HEAVY = ("torch", "tensorflow", "ultralytics", "retinaface")
+
+
+def _heavy_loaded():
+    """Heavy modules currently present in this interpreter's sys.modules."""
+    return [m for m in _HEAVY if m in sys.modules]
+
+
+def test_importing_detectors_is_torch_free():
+    """Importing the detectors package must not import torch/TensorFlow."""
+    pytest.importorskip("numpy")
+    pytest.importorskip("requests")
+
+    # Anything already imported by the test session shouldn't mask a regression:
+    # assert specifically that importing the package doesn't ADD a heavy module.
+    before = set(_heavy_loaded())
+    import detectors  # noqa: F401
+
+    added = set(_heavy_loaded()) - before
+    assert not added, f"Importing detectors eagerly imported heavy modules: {added}"
+
+
+def test_detector_registry_lists_both_backends():
+    """Both detectors register regardless of which ML backend is installed."""
+    pytest.importorskip("numpy")
+    pytest.importorskip("requests")
+
+    from detectors import list_detectors
+
+    registry = list_detectors()
+    assert "face_yolo" in registry
+    assert "face_retinaface" in registry
+    # variants are static metadata (no torch needed to enumerate them)
+    assert registry["face_yolo"]["variants"], "YOLO should advertise weight variants"
+
+
+def test_is_available_does_not_import_heavy():
+    """is_available() must answer via find_spec, never by importing the stack."""
+    pytest.importorskip("numpy")
+    pytest.importorskip("requests")
+
+    from detectors import face_yolo, face_retinaface
+
+    before = set(_heavy_loaded())
+    yolo_ok = face_yolo.is_available()
+    retina_ok = face_retinaface.is_available()
+
+    assert isinstance(yolo_ok, bool)
+    assert isinstance(retina_ok, bool)
+    added = set(_heavy_loaded()) - before
+    assert not added, f"is_available() eagerly imported heavy modules: {added}"
+
+
+def test_importing_face_detection_is_torch_free():
+    """Importing the orchestrator (which the subprocess does on startup) is
+    the actual ready-path import — it must stay torch/TF-free."""
+    pytest.importorskip("numpy")
+    pytest.importorskip("cv2")
+
+    before = set(_heavy_loaded())
+    import face_detection  # noqa: F401
+
+    added = set(_heavy_loaded()) - before
+    assert not added, f"Importing face_detection eagerly imported heavy modules: {added}"
+
+
+def test_get_available_models_is_torch_free():
+    """Populating the model dropdown must not import torch/TensorFlow."""
+    pytest.importorskip("numpy")
+    pytest.importorskip("cv2")
+
+    from face_detection import FaceDetectionProcessor
+
+    processor = FaceDetectionProcessor()
+    before = set(_heavy_loaded())
+    models = processor.get_available_models()
+
+    assert isinstance(models, (list, tuple))
+    added = set(_heavy_loaded()) - before
+    assert not added, f"get_available_models() eagerly imported heavy modules: {added}"
+
+
+def test_startup_path_torch_free_even_when_heavy_installed(tmp_path):
+    """The strongest guard: even when torch/TF/ultralytics/retina-face ARE
+    importable, walking the whole startup/ready path must import none of them.
+
+    We can't assume the real heavy stacks are installed in the test env, so we
+    fabricate importable stub modules and run the import path in a *fresh*
+    subprocess (to avoid this test's own sys.modules affecting others). If any
+    stub gets imported, the lazy-load has regressed.
+    """
+    pytest.importorskip("numpy")
+    pytest.importorskip("cv2")
+
+    stub_dir = tmp_path / "fakemods"
+    stub_dir.mkdir()
+    for name in ("torch", "ultralytics", "tensorflow", "retinaface"):
+        (stub_dir / f"{name}.py").write_text(f"IMPORTED_{name} = True\n")
+
+    script = textwrap.dedent(
+        f"""
+        import sys
+        sys.path.insert(0, {str(stub_dir)!r})   # heavy stubs importable (simulate installed)
+        sys.path.insert(0, {PYTHON_DIR!r})
+
+        import detectors
+        import face_detection
+        from face_detection import FaceDetectionProcessor
+
+        FaceDetectionProcessor().get_available_models()
+        detectors.list_detectors()
+        detectors.face_yolo.is_available()
+        detectors.face_retinaface.is_available()
+
+        heavy = [n for n in ("torch", "ultralytics", "tensorflow", "retinaface")
+                 if n in sys.modules]
+        if heavy:
+            print("LEAKED:" + ",".join(heavy))
+            sys.exit(1)
+        print("OK")
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        "Startup path imported heavy modules when they were installed:\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert "OK" in result.stdout

--- a/src/App.css
+++ b/src/App.css
@@ -482,9 +482,26 @@
   font-weight: 500;
 }
 
+.loading-substatus {
+  margin-top: 10px;
+  max-width: 80%;
+  font-size: 13px;
+  color: #666;
+  text-align: center;
+  word-break: break-word;
+}
+
+.loading-elapsed {
+  margin-top: 6px;
+  font-size: 12px;
+  color: #999;
+  font-variant-numeric: tabular-nums;
+}
+
 .loading-animation {
   display: flex;
   gap: 8px;
+  margin-top: 18px;
 }
 
 .dot {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,9 @@ const App = () => {
     const [completedResultsFolder, setCompletedResultsFolder] = useState("");
     const [isVideoFile, setIsVideoFile] = useState(false);
     const [pythonReady, setPythonReady] = useState(false);
+    // Live startup feedback for the loading screen: latest status line + elapsed time.
+    const [startupStatus, setStartupStatus] = useState<string>("");
+    const [startupElapsedMs, setStartupElapsedMs] = useState<number>(0);
 
     // Send command to Python via IPC
     const sendPythonCommand = useCallback((command: any): Promise<any> => {
@@ -222,7 +225,20 @@ const App = () => {
                 case 'completion':
                     handleCompletionEvent(eventData.data);
                     break;
-                    
+
+                case 'stderr':
+                    // Backend startup logs are forwarded here. While the app is
+                    // still warming up, show a readable "current step" so the
+                    // loading screen reflects real progress. Skip noisy [timing]
+                    // lines and empty output.
+                    if (typeof eventData.data === 'string') {
+                        const line = eventData.data.trim();
+                        if (line && !line.startsWith('[timing]')) {
+                            setStartupStatus(line);
+                        }
+                    }
+                    break;
+
                 default:
                     console.log("Unknown event type:", eventData.type);
             }
@@ -231,7 +247,16 @@ const App = () => {
         const handlePythonStatus = (event: any, statusData: any) => {
             console.log("Python status:", statusData);
             setPythonReady(statusData.ready);
-            
+
+            // Surface any status message / elapsed time the main process sends
+            // (e.g. the slow-startup warning) so the loading screen isn't static.
+            if (typeof statusData.message === "string" && statusData.message) {
+                setStartupStatus(statusData.message);
+            }
+            if (typeof statusData.elapsedMs === "number") {
+                setStartupElapsedMs(statusData.elapsedMs);
+            }
+
             if (statusData.ready && availableModels.length === 0) {
                 // Load models when Python becomes ready
                 loadAvailableModels();
@@ -531,6 +556,16 @@ const App = () => {
                 <div className="loading-message">
                     Starting up face detection engine...
                 </div>
+                {startupStatus && (
+                    <div className="loading-substatus">
+                        {startupStatus}
+                    </div>
+                )}
+                {startupElapsedMs > 0 && (
+                    <div className="loading-elapsed">
+                        {(startupElapsedMs / 1000).toFixed(0)}s
+                    </div>
+                )}
                 <div className="loading-animation">
                     <div className="dot"></div>
                     <div className="dot"></div>


### PR DESCRIPTION
## Why

Users reported very slow load times after installing and launching the desktop app. The Python subprocess emitted its `ready` signal — which dismisses the "Starting up face detection engine…" screen — only **after a full torch/ultralytics (or TensorFlow/RetinaFace) cold import**, and that heavy import happened **twice** on the launch path (once as a redundant version-probe in the launcher, once in the detector modules). This PR makes launch feel instant and moves the one-time ML import to first detection (where model weights already download).

> Note: `python-build-standalone` is already used to bundle the interpreter, so that lever was already in place — the remaining latency was the ML cold-import, not the interpreter.

## What changed

**1. Lazy-load the heavy ML libraries (the dominant win)**
- `python/detectors/face_yolo.py` / `face_retinaface.py` no longer import torch/ultralytics/retina-face at module top level; they import them inside `load()` / `detect_image()` / `_select_device()` on first use. `is_available()` now probes with `importlib.util.find_spec` (locates, never executes).
- `python/multi_env_launcher.py`: the redundant version-probe imports of the whole ML stack are replaced with import-free `find_spec` checks, so the launcher no longer cold-imports torch/TF before `subprocess_api` even loads.

**2. Startup instrumentation (measure the win)**
- `[timing]` phase lines gated behind the `STARTUP_TIMING` env var in the launcher, `subprocess_api.py`, and both Electron main files.
- The `ready` message now carries a `startupMs` field, surfaced by the Electron main.

**3. Native splash + deferred main-window reveal (perceived-instant GUI)**
- `main/index.ts` shows a self-contained (inline data-URL) splash the instant the app starts; the main window is created hidden and revealed on `ready-to-show`, then the splash closes. Tray + hide-on-close behavior unchanged.

**4. Surface real startup progress in the loading screen**
- `src/App.tsx` wires the `pythonStatus` message/elapsed and forwarded backend stderr into the "Starting up…" view instead of a static string.

## Tests

- New `python/tests/test_lazy_imports.py` (6 tests) asserts the startup/ready path imports no torch/TF — including a subprocess test that fabricates importable heavy stubs to prove the guarantee even when the real stacks aren't installed. Added `npm run test:python`.
- Verified locally: pytest **6 passed**; `tsc -p tsconfig.electronMain.json` clean; `npm run react-build` compiles successfully; `npm run lint` passes.
- End-to-end launcher run emits `{"type":"ready","startupMs":232}` (sub-second) with the import-free probe reporting PyTorch **"NOT found"** — i.e. torch is never imported on the ready path; its cold import now happens on first detection.

## Notes for reviewers

- Behavior change: both detector modules now always import cleanly and register, so `list_detectors()` includes both backends regardless of the active env. This is benign — `get_available_models()` still filters by `is_available()`.
- The `build-ubuntu` / `build-windows` workflows are `workflow_dispatch`-only; `build-macos` and `pages` run on this PR automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
