### PR TITLE
feat: info banner when a newer app release is available

### DIFF
--- a/main/index.ts
+++ b/main/index.ts
@@ -11,6 +11,7 @@ if (process.platform === "linux" && (process.env.APPIMAGE || process.env.APPDIR)
 import { app, BrowserWindow, ipcMain, dialog, shell, Tray, Menu, nativeImage } from "electron"; // tslint:disable-line
 import * as path from "path";
 import * as fs from "fs";
+import * as https from "https";
 
 // Wall-clock at main-process entry, used for lightweight startup phase timing.
 // Verbose [timing] lines are gated behind the STARTUP_TIMING env var; the phase
@@ -80,6 +81,145 @@ const isDev = (process.env.NODE_ENV === "development");
 let tray: Tray | null = null;
 let mainWindow: BrowserWindow | null = null;
 let splash: BrowserWindow | null = null;
+
+// --- Notify-only update check ------------------------------------------------
+// Surface an info banner in the renderer when a newer *app* release exists on
+// GitHub. The repo hosts model-weight releases (tags like `handobj-weights-v1`,
+// `v1.0.0-models`) alongside app releases (`v0.3.0`), and GitHub's
+// /releases/latest can point at a weights release — so we list all releases and
+// consider only tags shaped like a plain semver app version. Any failure
+// (offline, HTTP error, rate limit) resolves to "no update" and is logged, never
+// thrown, so the banner simply doesn't appear rather than breaking startup.
+const GITHUB_OWNER = "cardiff-babylab";
+const GITHUB_REPO = "tinyexplorer-detection-app";
+// Matches "v0.3.0" but not "v1.0.0-models" / "handobj-weights-v1" / prereleases.
+const APP_RELEASE_TAG = /^v(\d+)\.(\d+)\.(\d+)$/;
+
+interface UpdateInfo {
+    currentVersion: string;
+    latestVersion: string | null;
+    updateAvailable: boolean;
+    releaseUrl: string | null;
+    releaseName: string | null;
+    checked: boolean; // false when the check couldn't complete (offline/error)
+}
+
+function parseAppVersion(tagOrVersion: string): [number, number, number] | null {
+    const normalized = tagOrVersion.trim().startsWith("v") ? tagOrVersion.trim() : `v${tagOrVersion.trim()}`;
+    const m = APP_RELEASE_TAG.exec(normalized);
+    return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+
+// >0 if a is newer than b, <0 if older, 0 if equal.
+function compareVersion(a: [number, number, number], b: [number, number, number]): number {
+    for (let i = 0; i < 3; i++) {
+        if (a[i] !== b[i]) return a[i] - b[i];
+    }
+    return 0;
+}
+
+function fetchLatestAppRelease(): Promise<{ tag: string; name: string; url: string } | null> {
+    return new Promise((resolve) => {
+        const req = https.request(
+            {
+                hostname: "api.github.com",
+                path: `/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases?per_page=30`,
+                method: "GET",
+                headers: {
+                    "User-Agent": `${GITHUB_REPO}-update-check`,
+                    Accept: "application/vnd.github+json",
+                },
+                timeout: 5000,
+            },
+            (res) => {
+                const status = res.statusCode || 0;
+                if (status < 200 || status >= 300) {
+                    console.warn(`[update-check] GitHub API returned HTTP ${status}; skipping update check.`);
+                    res.resume(); // drain so the socket frees
+                    resolve(null);
+                    return;
+                }
+                let body = "";
+                res.setEncoding("utf8");
+                res.on("data", (chunk) => (body += chunk));
+                res.on("end", () => {
+                    try {
+                        const releases = JSON.parse(body);
+                        if (!Array.isArray(releases)) {
+                            console.warn("[update-check] Unexpected releases payload; skipping update check.");
+                            resolve(null);
+                            return;
+                        }
+                        let best: { tag: string; name: string; url: string; ver: [number, number, number] } | null = null;
+                        for (const r of releases) {
+                            if (!r || r.draft || r.prerelease) continue;
+                            const ver = parseAppVersion(String(r.tag_name || ""));
+                            if (!ver) continue; // skips weights/models/prerelease-shaped tags
+                            if (!best || compareVersion(ver, best.ver) > 0) {
+                                best = { tag: String(r.tag_name), name: String(r.name || r.tag_name), url: String(r.html_url), ver };
+                            }
+                        }
+                        resolve(best ? { tag: best.tag, name: best.name, url: best.url } : null);
+                    } catch (e) {
+                        console.warn("[update-check] Failed to parse releases response:", e);
+                        resolve(null);
+                    }
+                });
+            },
+        );
+        req.on("error", (e) => {
+            console.warn("[update-check] Network error during update check (offline?):", (e as Error).message);
+            resolve(null);
+        });
+        req.on("timeout", () => {
+            console.warn("[update-check] Update check timed out; skipping.");
+            req.destroy();
+            resolve(null);
+        });
+        req.end();
+    });
+}
+
+async function getUpdateInfo(): Promise<UpdateInfo> {
+    const currentVersion = app.getVersion();
+    const current = parseAppVersion(currentVersion);
+    const latest = await fetchLatestAppRelease();
+    if (!latest) {
+        return { currentVersion, latestVersion: null, updateAvailable: false, releaseUrl: null, releaseName: null, checked: false };
+    }
+    const latestVer = parseAppVersion(latest.tag);
+    const updateAvailable = Boolean(current && latestVer && compareVersion(latestVer, current) > 0);
+    return {
+        currentVersion,
+        latestVersion: latest.tag.replace(/^v/, ""),
+        updateAvailable,
+        releaseUrl: latest.url,
+        releaseName: latest.name,
+        checked: true,
+    };
+}
+
+// Registered at module scope (not inside createWindow) so it's wired exactly
+// once regardless of window re-creation.
+ipcMain.handle("check-for-updates", async (): Promise<UpdateInfo> => {
+    try {
+        return await getUpdateInfo();
+    } catch (error) {
+        console.warn("[update-check] Unexpected error during update check:", error);
+        return { currentVersion: app.getVersion(), latestVersion: null, updateAvailable: false, releaseUrl: null, releaseName: null, checked: false };
+    }
+});
+
+// Open an external https URL (e.g. the GitHub release page) in the default
+// browser. Restricted to https to avoid opening arbitrary schemes.
+ipcMain.handle("open-external", async (_event: any, url: string): Promise<boolean> => {
+    if (typeof url === "string" && /^https:\/\//i.test(url)) {
+        await shell.openExternal(url);
+        return true;
+    }
+    console.warn("[update-check] Refused to open non-https external URL:", url);
+    return false;
+});
 
 // Minimal, self-contained splash shown the instant the app starts, so the user
 // sees immediate feedback instead of a blank screen while the React bundle loads

--- a/main/index.ts
+++ b/main/index.ts
@@ -512,7 +512,7 @@ function createWindow() {
                 { name: 'CSV Files', extensions: ['csv'] },
                 { name: 'All Files', extensions: ['*'] }
             ],
-            defaultPath: 'face_detection_results.csv'
+            defaultPath: 'detection_results.csv'
         });
         if (!result.canceled && result.filePath) {
             event.sender.send("selected-save-path", result.filePath);

--- a/public/index.html
+++ b/public/index.html
@@ -58,6 +58,26 @@
                     removeListener: function(channel, callback) {
                         delete this.callbacks[channel];
                     },
+                    invoke: function(channel, data) {
+                        // Web/dev mode: no Electron main process. Resolve update
+                        // checks to "not checked / no update" so no banner shows,
+                        // and open external links in a new tab.
+                        if (channel === "check-for-updates") {
+                            return Promise.resolve({
+                                currentVersion: "dev",
+                                latestVersion: null,
+                                updateAvailable: false,
+                                releaseUrl: null,
+                                releaseName: null,
+                                checked: false
+                            });
+                        }
+                        if (channel === "open-external") {
+                            if (typeof data === "string") window.open(data, "_blank");
+                            return Promise.resolve(true);
+                        }
+                        return Promise.resolve(null);
+                    },
                     send: function(channel, data) {
                         console.log("IPC stub send:", channel, data === undefined ? "" : data);
                         

--- a/python/face_detection.py
+++ b/python/face_detection.py
@@ -316,10 +316,10 @@ class FaceDetectionProcessor:
             return None
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         if results_folder:
-            result_folder = os.path.join(results_folder, f"face_detection_results_{timestamp}")
+            result_folder = os.path.join(results_folder, f"detection_results_{timestamp}")
             self._emit(f"{_STATUS_SYMBOLS['folder']} Creating results folder: {result_folder}")
         else:
-            result_folder = os.path.join(os.getcwd(), f"face_detection_results_{timestamp}")
+            result_folder = os.path.join(os.getcwd(), f"detection_results_{timestamp}")
             self._emit(
                 f"{_STATUS_SYMBOLS['folder']} Creating default results folder: {result_folder}"
             )

--- a/src/App.css
+++ b/src/App.css
@@ -6,8 +6,75 @@
 
 .app-container {
   display: flex;
-  height: 100vh;
+  /* Fill the space under the optional update banner instead of a hard 100vh, so
+     the banner never pushes content off-screen. `.App` is a 100vh column flex. */
+  flex: 1;
+  min-height: 0;
   background-color: #f5f5f5;
+}
+
+/* Notify-only "a newer release is available" banner, pinned above the app. */
+.update-banner {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 16px;
+  background-color: #eff6ff;
+  border-bottom: 1px solid #bfdbfe;
+  color: #1e3a5f;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.update-banner-text {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.update-banner-icon {
+  font-size: 14px;
+}
+
+.update-banner-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.update-banner-link {
+  background-color: #2563eb;
+  color: #ffffff;
+  border: none;
+  border-radius: 5px;
+  padding: 5px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.update-banner-link:hover {
+  background-color: #1d4ed8;
+}
+
+.update-banner-dismiss {
+  background: transparent;
+  border: none;
+  color: #1e3a5f;
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: 4px;
+  opacity: 0.7;
+}
+
+.update-banner-dismiss:hover {
+  opacity: 1;
+  background-color: rgba(30, 58, 95, 0.08);
 }
 
 .left-panel {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,19 @@ const App = () => {
     // Live startup feedback for the loading screen: latest status line + elapsed time.
     const [startupStatus, setStartupStatus] = useState<string>("");
     const [startupElapsedMs, setStartupElapsedMs] = useState<number>(0);
+    // Notify-only "you're behind the latest release" banner. `updateInfo` is
+    // populated by a one-shot check against GitHub Releases (see main process);
+    // `updateBannerDismissed` hides it after the user closes it for that version.
+    type UpdateInfo = {
+        currentVersion: string;
+        latestVersion: string | null;
+        updateAvailable: boolean;
+        releaseUrl: string | null;
+        releaseName: string | null;
+        checked: boolean;
+    };
+    const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null);
+    const [updateBannerDismissed, setUpdateBannerDismissed] = useState<boolean>(false);
 
     // Send command to Python via IPC
     const sendPythonCommand = useCallback((command: any): Promise<any> => {
@@ -184,6 +197,48 @@ const App = () => {
                 break;
         }
     }, [fetchResults]);
+
+    // One-shot, notify-only update check against GitHub Releases. The main
+    // process does the network call and fails silently (offline/error -> no
+    // banner); here we just store the result and honour a per-version dismissal
+    // so the banner returns only when a newer release lands.
+    useEffect(() => {
+        let cancelled = false;
+        (async () => {
+            try {
+                if (!ipcRenderer || typeof ipcRenderer.invoke !== "function") return;
+                const info: UpdateInfo = await ipcRenderer.invoke("check-for-updates");
+                if (cancelled || !info) return;
+                setUpdateInfo(info);
+                if (info.updateAvailable && info.latestVersion) {
+                    const dismissedFor = window.localStorage.getItem("updateBannerDismissedVersion");
+                    if (dismissedFor === info.latestVersion) {
+                        setUpdateBannerDismissed(true);
+                    }
+                } else if (!info.checked) {
+                    console.warn("[FALLBACK] Update check did not complete (offline or GitHub unreachable); update banner suppressed.");
+                }
+            } catch (error) {
+                console.warn("[FALLBACK] Update check threw; update banner suppressed:", error);
+            }
+        })();
+        return () => { cancelled = true; };
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+    // Open the release page in the user's default browser (main process guards to https).
+    const handleOpenRelease = useCallback(() => {
+        if (updateInfo && updateInfo.releaseUrl && ipcRenderer && typeof ipcRenderer.invoke === "function") {
+            ipcRenderer.invoke("open-external", updateInfo.releaseUrl);
+        }
+    }, [updateInfo]);
+
+    // Hide the banner and remember the dismissal for this specific latest version.
+    const handleDismissUpdateBanner = useCallback(() => {
+        if (updateInfo && updateInfo.latestVersion) {
+            window.localStorage.setItem("updateBannerDismissedVersion", updateInfo.latestVersion);
+        }
+        setUpdateBannerDismissed(true);
+    }, [updateInfo]);
 
     // Handle Python events
     useEffect(() => {
@@ -577,6 +632,28 @@ const App = () => {
 
     return (
         <div className="App">
+            {updateInfo && updateInfo.updateAvailable && !updateBannerDismissed && (
+                <div className="update-banner" role="status">
+                    <span className="update-banner-text">
+                        <span className="update-banner-icon" role="img" aria-label="Update available">⬆️</span>
+                        A new version (v{updateInfo.latestVersion}) is available — you're on v{updateInfo.currentVersion}.
+                    </span>
+                    <span className="update-banner-actions">
+                        <button type="button" className="update-banner-link" onClick={handleOpenRelease}>
+                            View release
+                        </button>
+                        <button
+                            type="button"
+                            className="update-banner-dismiss"
+                            onClick={handleDismissUpdateBanner}
+                            aria-label="Dismiss update notification"
+                            title="Dismiss"
+                        >
+                            ✕
+                        </button>
+                    </span>
+                </div>
+            )}
             <div className="app-container">
                 <div className="left-panel">
                     <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '20px' }}>


### PR DESCRIPTION
## What
Adds a lightweight, **notify-only** update banner. On launch the app checks the GitHub Releases API and, if a newer **app** version exists, shows a dismissible info banner linking to the release page (opened in the default browser).

```
┌──────────────────────────────────────────────┐
│ ⬆ A new version (v0.4.0) is available —        │
│    you're on v0.3.0.   [ View release ] [ ✕ ]  │
└──────────────────────────────────────────────┘
```

## Why
A user running an older build previously had no in-app signal that a newer version had shipped.

## How
- **Main process** (`main/index.ts`): queries the Releases API over `https` (5s timeout, `User-Agent` header), filters to app-version tags and compares the highest to `app.getVersion()`. Adds IPC handlers `check-for-updates` and a https-guarded `open-external`, registered at module scope.
- **Renderer** (`src/App.tsx` / `src/App.css`): one-shot check on mount; dismissible banner, dismissal remembered per-version in `localStorage` so it returns only for a newer release.
- **Web-dev stub** (`public/index.html`): adds an `invoke` shim so `npm start` (browser mode) keeps working.

### Handles the mixed-releases gotcha
This repo hosts weight releases (`handobj-weights-v1`, `v1.0.0-models`) alongside app releases, and `/releases/latest` can point at a weights bundle. The check lists all releases and considers **only** plain semver tags (`^v\d+\.\d+\.\d+$`), ignoring weights and prereleases — so `v1.0.0-models` is never mistaken for a "1.0.0" upgrade.

### Failure behavior
Offline / HTTP error / rate limit → resolves to "no update", logged (never thrown) → the banner simply doesn't appear. Never blocks startup.

## Test
- `tsc --noEmit` clean for both `tsconfig.electronMain.json` (main) and `tsconfig.json` (renderer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Also in this PR
- `refactor(workflow): drop "face" prefix from results folder name` — the exported results folder is now `detection_results_<ts>` (was `face_detection_results_<ts>`), since the app detects more than faces. The save-CSV dialog default is updated to `detection_results.csv` to match the CSV already written inside the folder.
