### PR TITLE
ci(windows): split setup and portable into separate artifacts

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -271,10 +271,20 @@ jobs:
           exit 1
         }
 
-    - name: Upload Windows artifacts
+    # Upload the two installers as separate artifacts so users download only the
+    # one they need (~750 MB each) instead of a single ~1.5 GB bundle.
+    - name: Upload Windows setup installer (NSIS)
       uses: actions/upload-artifact@v4
       with:
-        name: windows-build
+        name: windows-setup
+        path: dist/*-setup.exe
+        if-no-files-found: warn
+
+    - name: Upload Windows portable
+      uses: actions/upload-artifact@v4
+      with:
+        name: windows-portable
         path: |
           dist/*.exe
+          !dist/*-setup.exe
         if-no-files-found: warn


### PR DESCRIPTION
The Windows build emits two installers (NSIS `-setup.exe` + `portable.exe`), currently uploaded together as one ~1.5 GB `windows-build` artifact — so downloading either means pulling both.

This splits them:
- `windows-setup` → `dist/*-setup.exe`
- `windows-portable` → `dist/*.exe` excluding `-setup.exe`

Each is ~750 MB, so users grab only what they need. No downstream job referenced the old `windows-build` name.

Takes effect on the next **Build Windows** run (workflow_dispatch).

Note (separate, not in this PR): GitHub Actions artifacts are always zipped by `upload-artifact`, which does nothing for already-compressed `.dmg`/`.exe`. Serving raw installers is a job for **GitHub Releases** — a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)